### PR TITLE
Performance/am pm

### DIFF
--- a/ctparse/time/rules.py
+++ b/ctparse/time/rules.py
@@ -441,10 +441,7 @@ def _is_valid_military_time(ts: datetime, t: Time) -> bool:
 def _maybe_apply_am_pm(t: Time, ampm_match: str) -> Time:
     if not t.hour:
         return t
-    #PM bias
     if ampm_match is None:
-        if t.hour <= 12:
-            t.hour += 12
         return t
     if ampm_match.lower().startswith("a") and t.hour <= 12:
         return t
@@ -663,14 +660,9 @@ def ruleDateTimeDateTime(
 
 @rule(predicate("isTOD"), _regex_to_join, predicate("isTOD"))
 def ruleTODTOD(ts: datetime, t1: Time, _: RegexMatch, t2: Time) -> Interval:
-    # PM BIAS 9-5 handling
-    if t1.hour > t2.hour:
-        t1.hour -= 12
+    if (t1.hour > t2.hour) and (t1.hour <= 12 and t2.hour <= 12):
+        t2.hour = t2.hour + 12
         return Interval(t_from=t1, t_to=t2)
-    # old AM bias 9-5 handling
-    # if (t1.hour > t2.hour) and (t1.hour <= 12 and t2.hour <= 12):
-    #     t2.hour = t2.hour + 12
-    #     return Interval(t_from=t1, t_to=t2)
     else:
         return Interval(t_from=t1, t_to=t2)
 

--- a/ctparse/time/rules.py
+++ b/ctparse/time/rules.py
@@ -441,7 +441,10 @@ def _is_valid_military_time(ts: datetime, t: Time) -> bool:
 def _maybe_apply_am_pm(t: Time, ampm_match: str) -> Time:
     if not t.hour:
         return t
+    #PM bias
     if ampm_match is None:
+        if t.hour <= 12:
+            t.hour += 12
         return t
     if ampm_match.lower().startswith("a") and t.hour <= 12:
         return t
@@ -660,9 +663,14 @@ def ruleDateTimeDateTime(
 
 @rule(predicate("isTOD"), _regex_to_join, predicate("isTOD"))
 def ruleTODTOD(ts: datetime, t1: Time, _: RegexMatch, t2: Time) -> Interval:
-    if (t1.hour > t2.hour) and (t1.hour <= 12 and t2.hour <= 12):
-        t2.hour = t2.hour + 12
+    # PM BIAS 9-5 handling
+    if t1.hour > t2.hour:
+        t1.hour -= 12
         return Interval(t_from=t1, t_to=t2)
+    # old AM bias 9-5 handling
+    # if (t1.hour > t2.hour) and (t1.hour <= 12 and t2.hour <= 12):
+    #     t2.hour = t2.hour + 12
+    #     return Interval(t_from=t1, t_to=t2)
     else:
         return Interval(t_from=t1, t_to=t2)
 


### PR DESCRIPTION
Performance update:
1. changed bias from AM to PM time reference:

`beers 4-5` now spits out `beers 4pm-5pm`

2. easy am suffix handling for intervals
`beers 4-5am` now spits out `beers 4am-5am`

The PM bias has been introduced because it covers more use cases than the AM bias. Coincidentally, the AM suffix is introduced as an easy and intuitive way to override the PM bias in intervals instead of specifying both start and end time as AM